### PR TITLE
feat(auth): implement email verification module

### DIFF
--- a/prisma/migrations/20251130222405_add_email_verification_tokens/migration.sql
+++ b/prisma/migrations/20251130222405_add_email_verification_tokens/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "email_verification_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "email_verification_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "email_verification_tokens_token_key" ON "email_verification_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "email_verification_tokens_user_id_idx" ON "email_verification_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "email_verification_tokens_token_idx" ON "email_verification_tokens"("token");
+
+-- AddForeignKey
+ALTER TABLE "email_verification_tokens" ADD CONSTRAINT "email_verification_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   notificationLogs  NotificationLog[]
   subscription      UserSubscription?
   passwordResetTokens PasswordResetToken[]
+  emailVerificationTokens EmailVerificationToken[]
 
   @@map("users")
 }
@@ -328,4 +329,18 @@ model PasswordResetToken {
   @@index([userId])
   @@index([token])
   @@map("password_reset_tokens")
+}
+
+model EmailVerificationToken {
+  id        String    @id @default(uuid())
+  userId    String    @map("user_id")
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  token     String    @unique
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@index([token])
+  @@map("email_verification_tokens")
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,6 +21,8 @@ import { CurrentUser } from './decorators/current-user.decorator';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { VerifyResetTokenDto } from './dto/verify-reset-token.dto';
+import { VerifyEmailDto } from './dto/verify-email.dto';
+import { ResendVerificationDto } from './dto/resend-verification.dto';
 
 @ApiTags('Autenticação')
 @Controller('auth')
@@ -73,5 +75,26 @@ export class AuthController {
   @ApiResponse({ status: 400, description: 'Token inválido/expirado' })
   async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
     return this.authService.resetPassword(resetPasswordDto);
+  }
+
+  @Post('verify-email')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verificar email com token' })
+  @ApiResponse({ status: 200, description: 'Email verificado com sucesso' })
+  @ApiResponse({ status: 400, description: 'Token inválido/expirado' })
+  @ApiResponse({ status: 409, description: 'Email já verificado' })
+  async verifyEmail(@Body() verifyEmailDto: VerifyEmailDto) {
+    return this.authService.verifyEmail(verifyEmailDto);
+  }
+
+  @Post('resend-verification')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reenviar email de verificação' })
+  @ApiResponse({ status: 200, description: 'Email reenviado (se existir)' })
+  @ApiResponse({ status: 409, description: 'Email já verificado' })
+  async resendVerification(
+    @Body() resendVerificationDto: ResendVerificationDto,
+  ) {
+    return this.authService.resendVerification(resendVerificationDto);
   }
 }

--- a/src/auth/dto/resend-verification.dto.ts
+++ b/src/auth/dto/resend-verification.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class ResendVerificationDto {
+  @ApiProperty({
+    example: 'joao@email.com',
+    description: 'Email para reenviar verificação',
+  })
+  @IsEmail({}, { message: 'Email inválido' })
+  email: string;
+}

--- a/src/auth/dto/verify-email.dto.ts
+++ b/src/auth/dto/verify-email.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class VerifyEmailDto {
+  @ApiProperty({
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+    description: 'Token de verificação recebido por email',
+  })
+  @IsString()
+  token: string;
+}

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -168,4 +168,126 @@ export class EmailService {
       this.logger.error('Falha ao enviar confirmação:', error);
     }
   }
+
+  /**
+   * Envia email de verificação
+   */
+  async sendEmailVerification(to: string, token: string, userName: string) {
+    const frontendUrl = this.configService.get('FRONTEND_URL');
+    const verifyUrl = `${frontendUrl}/verify-email?token=${token}`;
+
+    try {
+      const { data, error } = await this.resend.emails.send({
+        from: this.fromEmail,
+        to,
+        subject: '✉️ Confirme seu email - Miu Controle',
+        html: this.getEmailVerificationTemplate(userName, verifyUrl),
+      });
+
+      if (error) {
+        this.logger.error('Erro ao enviar verificação:', error);
+        throw error;
+      }
+
+      this.logger.log(`Email de verificação enviado para: ${to}`);
+      return data;
+    } catch (error) {
+      this.logger.error('Falha ao enviar verificação:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Template HTML para verificação de email
+   */
+  private getEmailVerificationTemplate(
+    userName: string,
+    verifyUrl: string,
+  ): string {
+    return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Verificação de Email</title>
+      </head>
+      <body style="margin: 0; padding: 0; font-family: 'Segoe UI', Arial, sans-serif; background-color: #f5f5f5;">
+        <table role="presentation" style="width: 100%; border-collapse: collapse;">
+          <tr>
+            <td align="center" style="padding: 40px 0;">
+              <table role="presentation" style="width: 600px; border-collapse: collapse; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
+                
+                <!-- Header -->
+                <tr>
+                  <td style="padding: 40px 40px 20px 40px; text-align: center; background: linear-gradient(135deg, #10B981 0%, #06B6D4 100%); border-radius: 8px 8px 0 0;">
+                    <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">✉️ Miu Controle</h1>
+                  </td>
+                </tr>
+
+                <!-- Body -->
+                <tr>
+                  <td style="padding: 40px;">
+                    <h2 style="margin: 0 0 20px 0; color: #1a1a1a; font-size: 24px; font-weight: 600;">
+                      Bem-vindo, ${userName}! 🎉
+                    </h2>
+                    
+                    <p style="margin: 0 0 20px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                      Obrigado por se cadastrar no Miu Controle!
+                    </p>
+
+                    <p style="margin: 0 0 30px 0; color: #666666; font-size: 16px; line-height: 1.6;">
+                      Para começar a usar sua conta, por favor confirme seu endereço de email clicando no botão abaixo:
+                    </p>
+
+                    <!-- Button -->
+                    <table role="presentation" style="margin: 0 auto;">
+                      <tr>
+                        <td style="border-radius: 6px; background: linear-gradient(135deg, #10B981 0%, #06B6D4 100%);">
+                          <a href="${verifyUrl}" target="_blank" style="display: inline-block; padding: 16px 40px; color: #ffffff; text-decoration: none; font-size: 16px; font-weight: 600; border-radius: 6px;">
+                            Confirmar Email
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Alternative Link -->
+                    <p style="margin: 30px 0 0 0; padding: 20px 0 0 0; border-top: 1px solid #e5e5e5; color: #999999; font-size: 14px; line-height: 1.6;">
+                      Ou copie e cole este link no seu navegador:<br>
+                      <a href="${verifyUrl}" style="color: #10B981; word-break: break-all;">${verifyUrl}</a>
+                    </p>
+
+                    <!-- Info -->
+                    <div style="margin: 20px 0 0 0; padding: 16px; background-color: #DBEAFE; border-left: 4px solid #3B82F6; border-radius: 4px;">
+                      <p style="margin: 0; color: #1E40AF; font-size: 14px; line-height: 1.6;">
+                        ℹ️ <strong>Importante:</strong> Este link expira em 24 horas.
+                      </p>
+                    </div>
+
+                    <p style="margin: 20px 0 0 0; color: #999999; font-size: 14px; line-height: 1.6;">
+                      Se você não criou esta conta, pode ignorar este email com segurança.
+                    </p>
+                  </td>
+                </tr>
+
+                <!-- Footer -->
+                <tr>
+                  <td style="padding: 30px 40px; text-align: center; background-color: #f9fafb; border-radius: 0 0 8px 8px;">
+                    <p style="margin: 0; color: #999999; font-size: 14px;">
+                      © ${new Date().getFullYear()} Miu Controle. Todos os direitos reservados.
+                    </p>
+                    <p style="margin: 10px 0 0 0; color: #999999; font-size: 12px;">
+                      Este é um email automático. Por favor, não responda.
+                    </p>
+                  </td>
+                </tr>
+
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>
+  `;
+  }
 }


### PR DESCRIPTION
- Add EmailVerificationToken model to Prisma schema
- Modify register to send verification email automatically
- Implement POST /auth/verify-email endpoint
- Implement POST /auth/resend-verification endpoint
- Add beautiful HTML email verification template
- Add token validation (expiry 24h, single-use)
- Mark user.emailVerified as true on success
- Prevent duplicate verifications
- Add comprehensive error handling
- Update Swagger documentation

Technical details:
- Token expires in 24 hours
- Token can only be used once
- Automatic old token invalidation
- Security: doesn't reveal if email exists (resend)
- Email sent automatically on registration

DTOs:
- VerifyEmailDto (token validation)
- ResendVerificationDto (email to resend)

Migration:
- Add email_verification_tokens table
- Add indexes for performance

Flow:
1. User registers → email sent automatically
2. User clicks link → token validated
3. User.emailVerified = true
4. Can resend if not received

Closes #15