### PR TITLE
feat(auth): implement sessions management module

### DIFF
--- a/prisma/migrations/20251130223528_add_session_info_to_refresh_tokens/migration.sql
+++ b/prisma/migrations/20251130223528_add_session_info_to_refresh_tokens/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "refresh_tokens" ADD COLUMN     "device_info" TEXT,
+ADD COLUMN     "ip_address" TEXT,
+ADD COLUMN     "last_used_at" TIMESTAMP(3),
+ADD COLUMN     "user_agent" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -311,6 +311,12 @@ model RefreshToken {
   expiresAt   DateTime  @map("expires_at")
   createdAt   DateTime  @default(now()) @map("created_at")
   revokedAt   DateTime? @map("revoked_at")
+  
+  // NOVOS CAMPOS
+  deviceInfo  String?   @map("device_info")  // Ex: "Chrome 120 - Windows 10"
+  ipAddress   String?   @map("ip_address")   // Ex: "192.168.1.100"
+  userAgent   String?   @map("user_agent")   // User-Agent completo
+  lastUsedAt  DateTime? @map("last_used_at") // Última vez que usou este token
 
   @@index([userId])
   @@index([token])

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { EmailModule } from '../email/email.module';
+import { SessionsService } from './sessions.service';
 
 @Module({
   imports: [
@@ -25,7 +26,7 @@ import { EmailModule } from '../email/email.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
-  exports: [AuthService],
+  providers: [AuthService, SessionsService, JwtStrategy],
+  exports: [AuthService, SessionsService],
 })
 export class AuthModule {}

--- a/src/auth/decorators/current-refresh-token.decorator.ts
+++ b/src/auth/decorators/current-refresh-token.decorator.ts
@@ -1,0 +1,13 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentRefreshToken = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    // Pegar do header Authorization: Bearer <token>
+    const authHeader = request.headers.authorization;
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      return authHeader.substring(7);
+    }
+    return null;
+  },
+);

--- a/src/auth/sessions.service.ts
+++ b/src/auth/sessions.service.ts
@@ -1,0 +1,115 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class SessionsService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Lista todas as sessões ativas do usuário
+   */
+  async getUserSessions(userId: string, currentToken: string) {
+    const sessions = await this.prisma.refreshToken.findMany({
+      where: {
+        userId,
+        revokedAt: null,
+        expiresAt: { gt: new Date() }, // Não expirados
+      },
+      select: {
+        id: true,
+        deviceInfo: true,
+        ipAddress: true,
+        lastUsedAt: true,
+        createdAt: true,
+        expiresAt: true,
+        token: true,
+      },
+      orderBy: {
+        lastUsedAt: 'desc',
+      },
+    });
+
+    // Marcar sessão atual
+    return sessions.map((session) => ({
+      id: session.id,
+      deviceInfo: session.deviceInfo || 'Dispositivo Desconhecido',
+      ipAddress: session.ipAddress || 'IP Desconhecido',
+      lastUsedAt: session.lastUsedAt,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+      isCurrent: session.token === currentToken,
+    }));
+  }
+
+  /**
+   * Revoga uma sessão específica
+   */
+  async revokeSession(userId: string, sessionId: string, currentToken: string) {
+    const session = await this.prisma.refreshToken.findUnique({
+      where: { id: sessionId },
+    });
+
+    if (!session) {
+      throw new NotFoundException('Sessão não encontrada');
+    }
+
+    if (session.userId !== userId) {
+      throw new ForbiddenException(
+        'Você não tem permissão para revogar esta sessão',
+      );
+    }
+
+    if (session.token === currentToken) {
+      throw new ForbiddenException(
+        'Você não pode revogar sua sessão atual. Use logout.',
+      );
+    }
+
+    await this.prisma.refreshToken.update({
+      where: { id: sessionId },
+      data: { revokedAt: new Date() },
+    });
+
+    return {
+      message: 'Sessão revogada com sucesso',
+    };
+  }
+
+  /**
+   * Revoga todas as sessões exceto a atual
+   */
+  async revokeAllSessions(userId: string, currentToken: string) {
+    const result = await this.prisma.refreshToken.updateMany({
+      where: {
+        userId,
+        token: { not: currentToken },
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    return {
+      message: `${result.count} sessão(ões) revogada(s) com sucesso`,
+      count: result.count,
+    };
+  }
+
+  /**
+   * Conta sessões ativas
+   */
+  async countActiveSessions(userId: string): Promise<number> {
+    return this.prisma.refreshToken.count({
+      where: {
+        userId,
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    });
+  }
+}

--- a/src/common/utils/device-info.util.ts
+++ b/src/common/utils/device-info.util.ts
@@ -1,0 +1,45 @@
+/**
+ * Extrai informações do dispositivo a partir do User-Agent
+ */
+export function parseDeviceInfo(userAgent: string): string {
+  if (!userAgent) return 'Dispositivo Desconhecido';
+
+  // Detectar SO
+  let os = 'Desconhecido';
+  if (userAgent.includes('Windows NT 10.0')) os = 'Windows 10';
+  else if (userAgent.includes('Windows NT 11.0')) os = 'Windows 11';
+  else if (userAgent.includes('Mac OS X')) os = 'macOS';
+  else if (userAgent.includes('Android')) os = 'Android';
+  else if (userAgent.includes('iPhone') || userAgent.includes('iPad'))
+    os = 'iOS';
+  else if (userAgent.includes('Linux')) os = 'Linux';
+
+  // Detectar navegador
+  let browser = 'Desconhecido';
+  if (userAgent.includes('Edg/')) browser = 'Edge';
+  else if (userAgent.includes('Chrome/') && !userAgent.includes('Edg/'))
+    browser = 'Chrome';
+  else if (userAgent.includes('Firefox/')) browser = 'Firefox';
+  else if (userAgent.includes('Safari/') && !userAgent.includes('Chrome/'))
+    browser = 'Safari';
+  else if (userAgent.includes('Opera/') || userAgent.includes('OPR/'))
+    browser = 'Opera';
+
+  // Extrair versão do navegador
+  let version = '';
+  const patterns = {
+    Chrome: /Chrome\/(\d+)/,
+    Firefox: /Firefox\/(\d+)/,
+    Safari: /Version\/(\d+)/,
+    Edge: /Edg\/(\d+)/,
+    Opera: /OPR\/(\d+)/,
+  };
+
+  const pattern = patterns[browser];
+  if (pattern) {
+    const match = userAgent.match(pattern);
+    if (match) version = match[1];
+  }
+
+  return `${browser}${version ? ' ' + version : ''} - ${os}`;
+}


### PR DESCRIPTION
- Add session info fields to RefreshToken model
- Add deviceInfo (browser + OS detection)
- Add ipAddress tracking
- Add lastUsedAt tracking
- Add userAgent storage
- Create SessionsService for session management
- Implement GET /auth/sessions endpoint
- Implement DELETE /auth/sessions/:id endpoint
- Implement DELETE /auth/sessions/revoke-all endpoint
- Create device-info parser utility
- Create CurrentRefreshToken decorator
- Update AuthService to capture session metadata
- Update register/login to track device and IP
- Prevent revoking current session
- Add session count helper method
- Update Swagger documentation

Technical details:
- Device detection from User-Agent
- IP address extraction from request
- Mark current session in list
- Cascade delete on user deletion
- Ordered by last used (most recent first)

Features:
- View all active sessions
- See device, IP, last access for each
- Revoke specific session remotely
- Revoke all sessions except current
- Security: can't revoke current session

Use cases:
- User sees suspicious login
- User changes device
- User wants to log out everywhere
- Admin panel future support

Closes #16