### PR TITLE
feat(projects): planejamento de despesas com orcamentos closes #79

### DIFF
--- a/prisma/migrations/20260223015000_add_projects_items_quotes_issue_79/migration.sql
+++ b/prisma/migrations/20260223015000_add_projects_items_quotes_issue_79/migration.sql
@@ -1,0 +1,80 @@
+-- CreateEnum
+CREATE TYPE "ProjectStatus" AS ENUM ('PLANNING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "ProjectItemStatus" AS ENUM ('PENDING', 'QUOTED', 'PURCHASED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "QuoteStatus" AS ENUM ('PENDING', 'SELECTED', 'REJECTED', 'CONVERTED');
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "ProjectStatus" NOT NULL DEFAULT 'PLANNING',
+    "total_budget" DECIMAL(15,2),
+    "deadline" TIMESTAMP(3),
+    "color" TEXT NOT NULL DEFAULT '#6366F1',
+    "icon" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "project_items" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "status" "ProjectItemStatus" NOT NULL DEFAULT 'PENDING',
+    "priority" INTEGER NOT NULL DEFAULT 3,
+    "transaction_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "quotes" (
+    "id" TEXT NOT NULL,
+    "item_id" TEXT NOT NULL,
+    "supplier_name" TEXT NOT NULL,
+    "price" DECIMAL(15,2) NOT NULL,
+    "additional_costs" DECIMAL(15,2) NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "status" "QuoteStatus" NOT NULL DEFAULT 'PENDING',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "quotes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "projects_user_id_status_idx" ON "projects"("user_id", "status");
+
+-- CreateIndex
+CREATE INDEX "projects_user_id_created_at_idx" ON "projects"("user_id", "created_at" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_items_transaction_id_key" ON "project_items"("transaction_id");
+
+-- CreateIndex
+CREATE INDEX "project_items_project_id_status_idx" ON "project_items"("project_id", "status");
+
+-- CreateIndex
+CREATE INDEX "quotes_item_id_status_idx" ON "quotes"("item_id", "status");
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "project_items" ADD CONSTRAINT "project_items_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quotes" ADD CONSTRAINT "quotes_item_id_fkey" FOREIGN KEY ("item_id") REFERENCES "project_items"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,9 @@ model User {
   socialAccounts        SocialAccount[]
   betterAuthSessions    BetterAuthSession[]
 
+  // Projects — Planejamento de Despesas (Issue #79)
+  projects              Project[]
+
   @@map("users")
 }
 
@@ -1172,4 +1175,94 @@ enum FeedbackStatus {
   IN_REVIEW
   RESOLVED
   REJECTED
+}
+
+// ==================== PROJECTS — Planejamento de Despesas com Orçamentos (Issue #79) ====================
+
+enum ProjectStatus {
+  PLANNING    // Em planejamento, nenhum item comprado ainda
+  IN_PROGRESS // Ao menos 1 item comprado
+  COMPLETED   // Todos os itens não-cancelados foram comprados
+  CANCELLED
+}
+
+enum ProjectItemStatus {
+  PENDING    // Sem cotações ainda
+  QUOTED     // Tem cotações, aguardando compra
+  PURCHASED  // Convertido em transação real
+  CANCELLED
+}
+
+enum QuoteStatus {
+  PENDING    // Aguardando análise
+  SELECTED   // Escolhido para comprar (apenas 1 por item)
+  REJECTED   // Descartado
+  CONVERTED  // Transação foi gerada a partir desta cotação
+}
+
+/// Projeto financeiro: agrupa itens de uma compra complexa (ex: "Arrumar Carro")
+model Project {
+  id          String        @id @default(uuid())
+  userId      String        @map("user_id")
+  user        User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  description String?
+  status      ProjectStatus @default(PLANNING)
+  /// Orçamento máximo estimado pelo usuário (opcional)
+  totalBudget Decimal?      @map("total_budget") @db.Decimal(15, 2)
+  deadline    DateTime?
+  color       String        @default("#6366F1")
+  icon        String?
+
+  items       ProjectItem[]
+
+  createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @updatedAt @map("updated_at")
+
+  @@index([userId, status])
+  @@index([userId, createdAt(sort: Desc)])
+  @@map("projects")
+}
+
+/// Item de um projeto (ex: "Bateria nova", "Troca de óleo")
+model ProjectItem {
+  id            String            @id @default(uuid())
+  projectId     String            @map("project_id")
+  project       Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  name          String
+  description   String?
+  quantity      Int               @default(1)
+  status        ProjectItemStatus @default(PENDING)
+  /// Prioridade: 1=urgente … 5=baixa prioridade
+  priority      Int               @default(3)
+  /// ID da Transaction criada ao converter orçamento (sem FK para evitar dependência circular)
+  transactionId String?           @unique @map("transaction_id")
+
+  quotes        Quote[]
+
+  createdAt     DateTime          @default(now()) @map("created_at")
+  updatedAt     DateTime          @updatedAt @map("updated_at")
+
+  @@index([projectId, status])
+  @@map("project_items")
+}
+
+/// Cotação de fornecedor para um ProjectItem (ex: AutoPeças - R$ 450)
+model Quote {
+  id              String      @id @default(uuid())
+  itemId          String      @map("item_id")
+  item            ProjectItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  supplierName    String      @map("supplier_name")
+  /// Preço principal do fornecedor
+  price           Decimal     @db.Decimal(15, 2)
+  /// Custos adicionais: frete, instalação, etc. (padrão: 0)
+  additionalCosts Decimal     @default(0) @map("additional_costs") @db.Decimal(15, 2)
+  notes           String?
+  status          QuoteStatus @default(PENDING)
+
+  createdAt       DateTime    @default(now()) @map("created_at")
+  updatedAt       DateTime    @updatedAt @map("updated_at")
+
+  @@index([itemId, status])
+  @@map("quotes")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,6 +46,7 @@ import { GamificationModule } from './gamification/gamification.module';
 import { BrandsModule } from './brands/brands.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { BetterAuthMiddleware } from './auth/better-auth.middleware';
+import { ProjectsModule } from './projects/projects.module';
 
 @Module({
   imports: [
@@ -141,6 +142,7 @@ import { BetterAuthMiddleware } from './auth/better-auth.middleware';
     GamificationModule,
     BrandsModule,
     OnboardingModule,
+    ProjectsModule, // Planejamento de Despesas com Orçamentos (Issue #79)
   ],
   providers: [
     // 🚦 ThrottlerGuard global

--- a/src/projects/dto/convert-quote.dto.ts
+++ b/src/projects/dto/convert-quote.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsUUID,
+  IsOptional,
+  IsDateString,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { Sanitize } from '../../common/decorators/sanitize.decorator';
+
+export class ConvertQuoteDto {
+  @ApiProperty({
+    example: 'uuid-da-conta',
+    description: 'ID da conta que será debitada',
+  })
+  @IsUUID()
+  accountId: string;
+
+  @ApiProperty({
+    example: 'uuid-da-categoria',
+    required: false,
+    description: 'ID da categoria para a transação (opcional)',
+  })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiProperty({
+    example: '2026-02-22',
+    required: false,
+    description: 'Data da compra (padrão: hoje)',
+  })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+
+  @ApiProperty({
+    example: 'Compra via projeto Arrumar Carro',
+    required: false,
+    description: 'Observação adicional para a transação (opcional)',
+  })
+  @Sanitize()
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  notes?: string;
+}

--- a/src/projects/dto/create-project-item.dto.ts
+++ b/src/projects/dto/create-project-item.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsInt,
+  Min,
+  Max,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { Sanitize } from '../../common/decorators/sanitize.decorator';
+
+export class CreateProjectItemDto {
+  @ApiProperty({ example: 'Bateria nova', description: 'Nome do item' })
+  @Sanitize()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(150)
+  name: string;
+
+  @ApiProperty({
+    example: 'Bateria de 60Ah para o modelo 2018',
+    required: false,
+  })
+  @Sanitize()
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiProperty({
+    example: 1,
+    required: false,
+    default: 1,
+    description: 'Quantidade do item',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(9999)
+  quantity?: number;
+
+  @ApiProperty({
+    example: 2,
+    required: false,
+    default: 3,
+    description: 'Prioridade: 1=urgente … 5=baixa',
+    minimum: 1,
+    maximum: 5,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  priority?: number;
+}

--- a/src/projects/dto/create-project.dto.ts
+++ b/src/projects/dto/create-project.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsDateString,
+  IsHexColor,
+  Min,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { Sanitize } from '../../common/decorators/sanitize.decorator';
+
+export class CreateProjectDto {
+  @ApiProperty({ example: 'Arrumar Carro', description: 'Nome do projeto' })
+  @Sanitize()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    example: 'Revisão completa do veículo antes da viagem',
+    required: false,
+  })
+  @Sanitize()
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiProperty({
+    example: 1500.0,
+    required: false,
+    description: 'Orçamento máximo total estimado (opcional)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  totalBudget?: number;
+
+  @ApiProperty({
+    example: '2026-03-15',
+    required: false,
+    description: 'Prazo limite para concluir o projeto',
+  })
+  @IsOptional()
+  @IsDateString()
+  deadline?: string;
+
+  @ApiProperty({ example: '#6366F1', required: false, default: '#6366F1' })
+  @IsOptional()
+  @IsHexColor()
+  color?: string;
+
+  @ApiProperty({ example: 'car', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  icon?: string;
+}

--- a/src/projects/dto/create-quote.dto.ts
+++ b/src/projects/dto/create-quote.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  Min,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { Sanitize } from '../../common/decorators/sanitize.decorator';
+
+export class CreateQuoteDto {
+  @ApiProperty({
+    example: 'AutoPeças Centro',
+    description: 'Nome do fornecedor',
+  })
+  @Sanitize()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(150)
+  supplierName: string;
+
+  @ApiProperty({ example: 450.0, description: 'Preço principal do fornecedor' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01, { message: 'Preço deve ser maior que zero' })
+  price: number;
+
+  @ApiProperty({
+    example: 30.0,
+    required: false,
+    default: 0,
+    description: 'Custos adicionais: frete, instalação, etc.',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  additionalCosts?: number;
+
+  @ApiProperty({
+    example: 'À vista, desconto de 5% no débito',
+    required: false,
+  })
+  @Sanitize()
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  notes?: string;
+}

--- a/src/projects/dto/update-project-item.dto.ts
+++ b/src/projects/dto/update-project-item.dto.ts
@@ -1,0 +1,16 @@
+import { PartialType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { ProjectItemStatus } from '@prisma/client';
+import { CreateProjectItemDto } from './create-project-item.dto';
+
+export class UpdateProjectItemDto extends PartialType(CreateProjectItemDto) {
+  @ApiProperty({
+    enum: ProjectItemStatus,
+    required: false,
+    description: 'Novo status do item (use convert para marcar como PURCHASED)',
+  })
+  @IsOptional()
+  @IsEnum(ProjectItemStatus)
+  status?: ProjectItemStatus;
+}

--- a/src/projects/dto/update-project.dto.ts
+++ b/src/projects/dto/update-project.dto.ts
@@ -1,0 +1,16 @@
+import { PartialType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { ProjectStatus } from '@prisma/client';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {
+  @ApiProperty({
+    enum: ProjectStatus,
+    required: false,
+    description: 'Novo status do projeto',
+  })
+  @IsOptional()
+  @IsEnum(ProjectStatus)
+  status?: ProjectStatus;
+}

--- a/src/projects/dto/update-quote.dto.ts
+++ b/src/projects/dto/update-quote.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateQuoteDto } from './create-quote.dto';
+
+export class UpdateQuoteDto extends PartialType(CreateQuoteDto) {}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -1,0 +1,331 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiBody,
+} from '@nestjs/swagger';
+import { ProjectsService } from './projects.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+import { CreateProjectItemDto } from './dto/create-project-item.dto';
+import { UpdateProjectItemDto } from './dto/update-project-item.dto';
+import { CreateQuoteDto } from './dto/create-quote.dto';
+import { UpdateQuoteDto } from './dto/update-quote.dto';
+import { ConvertQuoteDto } from './dto/convert-quote.dto';
+import { ProjectStatus } from '@prisma/client';
+
+@ApiTags('Projetos (Planejamento de Despesas)')
+@Controller('projects')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  // ═══════════════════════════════════════════════════════════════
+  //  PROJECTS
+  // ═══════════════════════════════════════════════════════════════
+
+  @Post()
+  @ApiOperation({
+    summary: 'Criar novo projeto',
+    description:
+      'Cria um projeto financeiro para organizar despesas complexas em itens e comparar orçamentos.',
+  })
+  @ApiResponse({ status: 201, description: 'Projeto criado com sucesso' })
+  create(@CurrentUser() user, @Body() dto: CreateProjectDto) {
+    return this.projectsService.createProject(user.id, dto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Listar projetos',
+    description: 'Lista todos os projetos do usuário, com contagem de itens.',
+  })
+  @ApiQuery({
+    name: 'status',
+    enum: ProjectStatus,
+    required: false,
+    description: 'Filtrar por status',
+  })
+  @ApiResponse({ status: 200, description: 'Lista de projetos' })
+  findAll(@CurrentUser() user, @Query('status') status?: ProjectStatus) {
+    return this.projectsService.findAllProjects(user.id, status);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Detalhes do projeto',
+    description:
+      'Retorna o projeto completo com todos os itens e cotações associadas.',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiResponse({ status: 200, description: 'Projeto encontrado' })
+  @ApiResponse({ status: 404, description: 'Projeto não encontrado' })
+  findOne(@Param('id') id: string, @CurrentUser() user) {
+    return this.projectsService.findOneProject(user.id, id);
+  }
+
+  @Get(':id/summary')
+  @ApiOperation({
+    summary: 'Dashboard do projeto',
+    description:
+      'Retorna estatísticas: total orçado vs gasto, economia em relação aos orçamentos descartados, progresso de itens.',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiResponse({ status: 200, description: 'Resumo calculado com sucesso' })
+  @ApiResponse({ status: 404, description: 'Projeto não encontrado' })
+  getSummary(@Param('id') id: string, @CurrentUser() user) {
+    return this.projectsService.getProjectSummary(user.id, id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Atualizar projeto' })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiResponse({ status: 200, description: 'Projeto atualizado' })
+  @ApiResponse({ status: 404, description: 'Projeto não encontrado' })
+  update(
+    @Param('id') id: string,
+    @CurrentUser() user,
+    @Body() dto: UpdateProjectDto,
+  ) {
+    return this.projectsService.updateProject(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Remover projeto',
+    description:
+      'Remove o projeto e todos os itens/cotações associados (cascade). Transações geradas são preservadas.',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiResponse({ status: 200, description: 'Projeto removido' })
+  @ApiResponse({ status: 404, description: 'Projeto não encontrado' })
+  remove(@Param('id') id: string, @CurrentUser() user) {
+    return this.projectsService.removeProject(user.id, id);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  PROJECT ITEMS
+  // ═══════════════════════════════════════════════════════════════
+
+  @Post(':id/items')
+  @ApiOperation({
+    summary: 'Adicionar item ao projeto',
+    description:
+      'Adiciona um item (ex: "Bateria nova") ao projeto para receber cotações.',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiResponse({ status: 201, description: 'Item adicionado' })
+  @ApiResponse({ status: 404, description: 'Projeto não encontrado' })
+  addItem(
+    @Param('id') id: string,
+    @CurrentUser() user,
+    @Body() dto: CreateProjectItemDto,
+  ) {
+    return this.projectsService.addItem(user.id, id, dto);
+  }
+
+  @Patch(':id/items/:itemId')
+  @ApiOperation({ summary: 'Atualizar item do projeto' })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiResponse({ status: 200, description: 'Item atualizado' })
+  @ApiResponse({ status: 404, description: 'Item não encontrado' })
+  updateItem(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @CurrentUser() user,
+    @Body() dto: UpdateProjectItemDto,
+  ) {
+    return this.projectsService.updateItem(user.id, id, itemId, dto);
+  }
+
+  @Delete(':id/items/:itemId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remover item do projeto' })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiResponse({ status: 200, description: 'Item removido' })
+  @ApiResponse({ status: 404, description: 'Item não encontrado' })
+  removeItem(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @CurrentUser() user,
+  ) {
+    return this.projectsService.removeItem(user.id, id, itemId);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  QUOTES
+  // ═══════════════════════════════════════════════════════════════
+
+  @Post(':id/items/:itemId/quotes')
+  @ApiOperation({
+    summary: 'Adicionar cotação ao item',
+    description:
+      'Cria uma cotação de fornecedor para o item (ex: AutoPeças - R$ 450).',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiResponse({ status: 201, description: 'Cotação adicionada' })
+  @ApiResponse({
+    status: 409,
+    description: 'Item já comprado — cotações não aceitas',
+  })
+  addQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @CurrentUser() user,
+    @Body() dto: CreateQuoteDto,
+  ) {
+    return this.projectsService.addQuote(user.id, id, itemId, dto);
+  }
+
+  @Patch(':id/items/:itemId/quotes/:quoteId')
+  @ApiOperation({ summary: 'Atualizar cotação' })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiParam({ name: 'quoteId', description: 'ID da cotação' })
+  @ApiResponse({ status: 200, description: 'Cotação atualizada' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cotação já convertida em transação',
+  })
+  updateQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @Param('quoteId') quoteId: string,
+    @CurrentUser() user,
+    @Body() dto: UpdateQuoteDto,
+  ) {
+    return this.projectsService.updateQuote(user.id, id, itemId, quoteId, dto);
+  }
+
+  @Delete(':id/items/:itemId/quotes/:quoteId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remover cotação' })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiParam({ name: 'quoteId', description: 'ID da cotação' })
+  @ApiResponse({ status: 200, description: 'Cotação removida' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cotação já convertida em transação',
+  })
+  removeQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @Param('quoteId') quoteId: string,
+    @CurrentUser() user,
+  ) {
+    return this.projectsService.removeQuote(user.id, id, itemId, quoteId);
+  }
+
+  @Patch(':id/items/:itemId/quotes/:quoteId/select')
+  @ApiOperation({
+    summary: 'Selecionar cotação',
+    description:
+      'Marca esta cotação como SELECTED e desmarca automaticamente as demais cotações do mesmo item.',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiParam({ name: 'quoteId', description: 'ID da cotação a selecionar' })
+  @ApiResponse({
+    status: 200,
+    description: 'Cotação selecionada com sucesso',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Cotação já convertida em transação',
+  })
+  selectQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @Param('quoteId') quoteId: string,
+    @CurrentUser() user,
+  ) {
+    return this.projectsService.selectQuote(user.id, id, itemId, quoteId);
+  }
+
+  @Patch(':id/items/:itemId/quotes/:quoteId/reject')
+  @ApiOperation({
+    summary: 'Rejeitar cotação',
+    description: 'Marca esta cotação como REJECTED (descartada).',
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item' })
+  @ApiParam({ name: 'quoteId', description: 'ID da cotação' })
+  @ApiResponse({ status: 200, description: 'Cotação rejeitada' })
+  rejectQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @Param('quoteId') quoteId: string,
+    @CurrentUser() user,
+  ) {
+    return this.projectsService.rejectQuote(user.id, id, itemId, quoteId);
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  CONVERT
+  // ═══════════════════════════════════════════════════════════════
+
+  @Post(':id/items/:itemId/convert')
+  @ApiOperation({
+    summary: 'Converter cotação selecionada em transação',
+    description: `
+Fluxo completo de conversão:
+1. Valida que o item não foi comprado (evita duplicidade)
+2. Localiza a cotação com status SELECTED
+3. Cria uma Transaction EXPENSE com o valor total (preço + adicionais)
+4. Debita o saldo da conta informada
+5. Atualiza o item para PURCHASED e a cotação para CONVERTED
+6. Recalcula o status do projeto (PLANNING → IN_PROGRESS → COMPLETED)
+    `,
+  })
+  @ApiParam({ name: 'id', description: 'ID do projeto' })
+  @ApiParam({ name: 'itemId', description: 'ID do item a comprar' })
+  @ApiBody({ type: ConvertQuoteDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Transação criada e item marcado como comprado',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Item já foi comprado anteriormente',
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Nenhuma cotação está selecionada para este item',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Conta ou categoria não encontrada',
+  })
+  convertQuote(
+    @Param('id') id: string,
+    @Param('itemId') itemId: string,
+    @CurrentUser() user,
+    @Body() dto: ConvertQuoteDto,
+  ) {
+    return this.projectsService.convertQuote(user.id, id, itemId, dto);
+  }
+}

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { ProjectsController } from './projects.controller';
+import { WebsocketModule } from '../websocket/websocket.module';
+
+@Module({
+  imports: [WebsocketModule],
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+  exports: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/src/projects/projects.service.spec.ts
+++ b/src/projects/projects.service.spec.ts
@@ -1,0 +1,556 @@
+/// <reference types="jest" />
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectsService } from './projects.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { WebsocketService } from '../websocket/websocket.service';
+import { CacheService } from '../common/services/cache.service';
+import {
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ProjectStatus, ProjectItemStatus, QuoteStatus } from '@prisma/client';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const USER_ID = 'user-001';
+const OTHER_USER = 'user-999';
+const PROJECT_ID = 'proj-001';
+const ITEM_ID = 'item-001';
+const QUOTE_ID = 'quote-001';
+const ACCOUNT_ID = 'acc-001';
+
+const makeProject = (overrides = {}) => ({
+  id: PROJECT_ID,
+  userId: USER_ID,
+  name: 'Arrumar Carro',
+  description: null,
+  status: ProjectStatus.PLANNING,
+  totalBudget: null,
+  deadline: null,
+  color: '#6366F1',
+  icon: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  _count: { items: 0 },
+  ...overrides,
+});
+
+const makeItem = (overrides = {}) => ({
+  id: ITEM_ID,
+  projectId: PROJECT_ID,
+  name: 'Bateria nova',
+  description: null,
+  quantity: 1,
+  status: ProjectItemStatus.PENDING,
+  priority: 3,
+  transactionId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  project: { id: PROJECT_ID, userId: USER_ID, name: 'Arrumar Carro' },
+  quotes: [],
+  ...overrides,
+});
+
+const makeQuote = (overrides = {}) => ({
+  id: QUOTE_ID,
+  itemId: ITEM_ID,
+  supplierName: 'AutoPeças',
+  price: 450,
+  additionalCosts: 0,
+  notes: null,
+  status: QuoteStatus.PENDING,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  item: {
+    projectId: PROJECT_ID,
+    project: { id: PROJECT_ID, userId: USER_ID },
+  },
+  ...overrides,
+});
+
+const mockPrisma = {
+  project: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  projectItem: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  quote: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+  },
+  account: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  category: {
+    findUnique: jest.fn(),
+  },
+  transaction: {
+    create: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+const mockWebsocket = {
+  emitToUser: jest.fn(),
+};
+
+const mockCache = {
+  invalidateUserCache: jest.fn(),
+};
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('ProjectsService', () => {
+  let service: ProjectsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectsService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: WebsocketService, useValue: mockWebsocket },
+        { provide: CacheService, useValue: mockCache },
+      ],
+    }).compile();
+
+    service = module.get<ProjectsService>(ProjectsService);
+
+    // Reset todos os mocks antes de cada teste
+    jest.clearAllMocks();
+  });
+
+  // ═══ createProject ═══════════════════════════════════════════════════════════
+
+  describe('createProject', () => {
+    it('deve criar projeto com os dados corretos', async () => {
+      const created = makeProject({ name: 'Reforma' });
+      mockPrisma.project.create.mockResolvedValue(created);
+
+      const result = await service.createProject(USER_ID, {
+        name: 'Reforma',
+        color: '#FF0000',
+      });
+
+      expect(mockPrisma.project.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: USER_ID,
+            name: 'Reforma',
+            status: ProjectStatus.PLANNING,
+          }),
+        }),
+      );
+      expect(result).toEqual(created);
+    });
+
+    it('deve invalidar o cache após criar projeto', async () => {
+      mockPrisma.project.create.mockResolvedValue(makeProject());
+      await service.createProject(USER_ID, { name: 'Proj' });
+      expect(mockCache.invalidateUserCache).toHaveBeenCalledWith(USER_ID);
+    });
+  });
+
+  // ═══ findOneProject ═══════════════════════════════════════════════════════════
+
+  describe('findOneProject', () => {
+    it('deve retornar projeto do usuário', async () => {
+      const proj = makeProject();
+      mockPrisma.project.findUnique.mockResolvedValue(proj);
+      const result = await service.findOneProject(USER_ID, PROJECT_ID);
+      expect(result).toEqual(proj);
+    });
+
+    it('deve lançar NotFoundException se projeto não existe', async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(null);
+      await expect(
+        service.findOneProject(USER_ID, 'inexistente'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('deve lançar NotFoundException se projeto pertence a outro usuário', async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(
+        makeProject({ userId: OTHER_USER }),
+      );
+      await expect(service.findOneProject(USER_ID, PROJECT_ID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ═══ addItem ═════════════════════════════════════════════════════════════════
+
+  describe('addItem', () => {
+    it('deve adicionar item ao projeto com status PENDING', async () => {
+      const proj = {
+        id: PROJECT_ID,
+        userId: USER_ID,
+        name: 'P',
+        status: ProjectStatus.PLANNING,
+      };
+      const item = makeItem();
+      mockPrisma.project.findUnique.mockResolvedValue(proj);
+      mockPrisma.projectItem.create.mockResolvedValue(item);
+
+      const result = await service.addItem(USER_ID, PROJECT_ID, {
+        name: 'Bateria nova',
+      });
+
+      expect(mockPrisma.projectItem.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            projectId: PROJECT_ID,
+            name: 'Bateria nova',
+            status: ProjectItemStatus.PENDING,
+          }),
+        }),
+      );
+      expect(result).toEqual(item);
+    });
+
+    it('deve lançar NotFoundException ao adicionar item em projeto de outro usuário', async () => {
+      mockPrisma.project.findUnique.mockResolvedValue(
+        makeProject({ userId: OTHER_USER }),
+      );
+      await expect(
+        service.addItem(USER_ID, PROJECT_ID, { name: 'Bateria' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ═══ addQuote ════════════════════════════════════════════════════════════════
+
+  describe('addQuote', () => {
+    it('deve adicionar cotação e atualizar status do item para QUOTED', async () => {
+      const item = makeItem({ status: ProjectItemStatus.PENDING, quotes: [] });
+      const quote = makeQuote();
+      mockPrisma.projectItem.findUnique.mockResolvedValue(item);
+      mockPrisma.quote.create.mockResolvedValue(quote);
+      mockPrisma.projectItem.update.mockResolvedValue({});
+
+      await service.addQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+        supplierName: 'AutoPeças',
+        price: 450,
+      });
+
+      expect(mockPrisma.projectItem.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: ProjectItemStatus.QUOTED },
+        }),
+      );
+    });
+
+    it('não deve atualizar status se item já está em QUOTED', async () => {
+      const item = makeItem({
+        status: ProjectItemStatus.QUOTED,
+        quotes: [makeQuote()],
+      });
+      mockPrisma.projectItem.findUnique.mockResolvedValue(item);
+      mockPrisma.quote.create.mockResolvedValue(makeQuote({ id: 'quote-002' }));
+
+      await service.addQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+        supplierName: 'MercadoLivre',
+        price: 420,
+        additionalCosts: 30,
+      });
+
+      // update NÃO deve ser chamado pois item já está QUOTED
+      expect(mockPrisma.projectItem.update).not.toHaveBeenCalled();
+    });
+
+    it('deve lançar ConflictException ao adicionar cotação em item PURCHASED', async () => {
+      const item = makeItem({ status: ProjectItemStatus.PURCHASED });
+      mockPrisma.projectItem.findUnique.mockResolvedValue(item);
+
+      await expect(
+        service.addQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+          supplierName: 'X',
+          price: 100,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ═══ selectQuote ═════════════════════════════════════════════════════════════
+
+  describe('selectQuote', () => {
+    it('deve selecionar cotação e desmarcar as demais do item', async () => {
+      const quote = makeQuote({ status: QuoteStatus.PENDING });
+      mockPrisma.quote.findUnique.mockResolvedValue(quote);
+      mockPrisma.$transaction.mockImplementation(async (ops) => {
+        return Promise.all(ops);
+      });
+      mockPrisma.quote.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.quote.update.mockResolvedValue({
+        ...quote,
+        status: QuoteStatus.SELECTED,
+      });
+
+      await service.selectQuote(USER_ID, PROJECT_ID, ITEM_ID, QUOTE_ID);
+
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it('deve lançar ConflictException ao selecionar cotação já CONVERTED', async () => {
+      mockPrisma.quote.findUnique.mockResolvedValue(
+        makeQuote({ status: QuoteStatus.CONVERTED }),
+      );
+      await expect(
+        service.selectQuote(USER_ID, PROJECT_ID, ITEM_ID, QUOTE_ID),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ═══ convertQuote ════════════════════════════════════════════════════════════
+
+  describe('convertQuote', () => {
+    const mockItemWithProject = makeItem({
+      status: ProjectItemStatus.QUOTED,
+    });
+    const mockSelectedQuote = {
+      id: QUOTE_ID,
+      itemId: ITEM_ID,
+      price: 450,
+      additionalCosts: 30,
+      supplierName: 'AutoPeças',
+      status: QuoteStatus.SELECTED,
+    };
+    const mockAccount = {
+      id: ACCOUNT_ID,
+      userId: USER_ID,
+      currentBalance: 1000,
+    };
+    const mockTransaction = {
+      id: 'tx-001',
+      amount: 480,
+      description: '[Projeto] Bateria nova',
+      type: 'EXPENSE',
+      category: null,
+      account: mockAccount,
+    };
+
+    it('deve criar transação e marcar item como PURCHASED', async () => {
+      mockPrisma.projectItem.findUnique.mockResolvedValue(mockItemWithProject);
+      mockPrisma.quote.findFirst.mockResolvedValue(mockSelectedQuote);
+      mockPrisma.account.findUnique.mockResolvedValue(mockAccount);
+      mockPrisma.$transaction.mockImplementation(async (fn) =>
+        fn({
+          transaction: { create: jest.fn().mockResolvedValue(mockTransaction) },
+          account: { update: jest.fn().mockResolvedValue({}) },
+          quote: { update: jest.fn().mockResolvedValue({}) },
+          projectItem: {
+            update: jest.fn().mockResolvedValue({
+              ...mockItemWithProject,
+              status: ProjectItemStatus.PURCHASED,
+              transactionId: 'tx-001',
+            }),
+          },
+        }),
+      );
+      mockPrisma.projectItem.findMany.mockResolvedValue([
+        { status: ProjectItemStatus.PURCHASED },
+      ]);
+      mockPrisma.project.update.mockResolvedValue({});
+
+      const result = await service.convertQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+        accountId: ACCOUNT_ID,
+      });
+
+      expect(result).toHaveProperty('transaction');
+      expect(result).toHaveProperty('projectStatus');
+      expect(mockWebsocket.emitToUser).toHaveBeenCalledWith(
+        USER_ID,
+        expect.any(String),
+        expect.any(Object),
+      );
+    });
+
+    it('deve lançar ConflictException se item já foi comprado', async () => {
+      mockPrisma.projectItem.findUnique.mockResolvedValue(
+        makeItem({ status: ProjectItemStatus.PURCHASED }),
+      );
+      await expect(
+        service.convertQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+          accountId: ACCOUNT_ID,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('deve lançar UnprocessableEntityException se não há cotação SELECTED', async () => {
+      mockPrisma.projectItem.findUnique.mockResolvedValue(mockItemWithProject);
+      mockPrisma.quote.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.convertQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+          accountId: ACCOUNT_ID,
+        }),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+
+    it('deve lançar NotFoundException se conta não existe', async () => {
+      mockPrisma.projectItem.findUnique.mockResolvedValue(mockItemWithProject);
+      mockPrisma.quote.findFirst.mockResolvedValue(mockSelectedQuote);
+      mockPrisma.account.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.convertQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+          accountId: 'acc-inexistente',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('deve lançar ForbiddenException se conta pertence a outro usuário', async () => {
+      mockPrisma.projectItem.findUnique.mockResolvedValue(mockItemWithProject);
+      mockPrisma.quote.findFirst.mockResolvedValue(mockSelectedQuote);
+      mockPrisma.account.findUnique.mockResolvedValue({
+        ...mockAccount,
+        userId: OTHER_USER,
+      });
+
+      await expect(
+        service.convertQuote(USER_ID, PROJECT_ID, ITEM_ID, {
+          accountId: ACCOUNT_ID,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ═══ syncProjectStatus (via removeItem) ══════════════════════════════════════
+
+  describe('syncProjectStatus', () => {
+    it('deve marcar projeto como COMPLETED quando todos os itens estão PURCHASED', async () => {
+      const proj = {
+        id: PROJECT_ID,
+        userId: USER_ID,
+        name: 'P',
+        status: ProjectStatus.IN_PROGRESS,
+      };
+      const item = makeItem();
+      mockPrisma.project.findUnique.mockResolvedValue(proj);
+      mockPrisma.projectItem.findUnique.mockResolvedValue(item);
+      mockPrisma.projectItem.delete.mockResolvedValue({});
+      // Após remoção, apenas itens PURCHASED restam
+      mockPrisma.projectItem.findMany.mockResolvedValue([
+        { status: ProjectItemStatus.PURCHASED },
+      ]);
+      mockPrisma.project.update.mockResolvedValue({});
+
+      await service.removeItem(USER_ID, PROJECT_ID, ITEM_ID);
+
+      expect(mockPrisma.project.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: ProjectStatus.COMPLETED },
+        }),
+      );
+    });
+
+    it('deve manter status PLANNING quando não há itens', async () => {
+      const proj = {
+        id: PROJECT_ID,
+        userId: USER_ID,
+        name: 'P',
+        status: ProjectStatus.PLANNING,
+      };
+      const item = makeItem();
+      mockPrisma.project.findUnique.mockResolvedValue(proj);
+      mockPrisma.projectItem.findUnique.mockResolvedValue(item);
+      mockPrisma.projectItem.delete.mockResolvedValue({});
+      mockPrisma.projectItem.findMany.mockResolvedValue([]);
+      mockPrisma.project.update.mockResolvedValue({});
+
+      await service.removeItem(USER_ID, PROJECT_ID, ITEM_ID);
+
+      expect(mockPrisma.project.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: ProjectStatus.PLANNING },
+        }),
+      );
+    });
+  });
+
+  // ═══ getProjectSummary ════════════════════════════════════════════════════════
+
+  describe('getProjectSummary', () => {
+    it('deve calcular corretamente totalBudgeted, totalSpent e savingsVsRejected', async () => {
+      const project = {
+        ...makeProject({ totalBudget: 1000 }),
+        items: [
+          {
+            id: ITEM_ID,
+            name: 'Bateria',
+            status: ProjectItemStatus.PURCHASED,
+            quotes: [
+              {
+                id: 'q1',
+                status: QuoteStatus.CONVERTED,
+                price: 450,
+                additionalCosts: 0,
+              },
+              {
+                id: 'q2',
+                status: QuoteStatus.REJECTED,
+                price: 480,
+                additionalCosts: 30,
+              },
+            ],
+          },
+        ],
+      };
+      mockPrisma.project.findUnique.mockResolvedValue(project);
+
+      const summary = await service.getProjectSummary(USER_ID, PROJECT_ID);
+
+      expect(summary.stats.totalBudgeted).toBe(450);
+      expect(summary.stats.totalSpent).toBe(450);
+      // REJECTED era 510 (480+30), SELECTED era 450 → economia: 510 - 450 = 60
+      expect(summary.stats.savingsVsRejected).toBe(60);
+      expect(summary.stats.progressPercent).toBe(100);
+    });
+
+    it('deve retornar 0% de progresso quando não há itens comprados', async () => {
+      const project = {
+        ...makeProject(),
+        items: [
+          {
+            id: ITEM_ID,
+            name: 'Óleo',
+            status: ProjectItemStatus.QUOTED,
+            quotes: [
+              {
+                id: 'q1',
+                status: QuoteStatus.SELECTED,
+                price: 120,
+                additionalCosts: 0,
+              },
+            ],
+          },
+        ],
+      };
+      mockPrisma.project.findUnique.mockResolvedValue(project);
+
+      const summary = await service.getProjectSummary(USER_ID, PROJECT_ID);
+
+      expect(summary.stats.progressPercent).toBe(0);
+      expect(summary.stats.totalSpent).toBe(0);
+      expect(summary.stats.totalBudgeted).toBe(120);
+    });
+  });
+});

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -1,0 +1,815 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  UnprocessableEntityException,
+  Logger,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { WebsocketService } from '../websocket/websocket.service';
+import { WS_EVENTS } from '../websocket/events/websocket.events';
+import { CacheService } from '../common/services/cache.service';
+import {
+  ProjectStatus,
+  ProjectItemStatus,
+  QuoteStatus,
+  TransactionType,
+  TransactionStatus,
+  TransactionSource,
+  Prisma,
+} from '@prisma/client';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+import { CreateProjectItemDto } from './dto/create-project-item.dto';
+import { UpdateProjectItemDto } from './dto/update-project-item.dto';
+import { CreateQuoteDto } from './dto/create-quote.dto';
+import { UpdateQuoteDto } from './dto/update-quote.dto';
+import { ConvertQuoteDto } from './dto/convert-quote.dto';
+
+// ─── Seletor compartilhado para Quote ──────────────────────────────────────────
+const QUOTE_SELECT = {
+  id: true,
+  supplierName: true,
+  price: true,
+  additionalCosts: true,
+  notes: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+// ─── Seletor compartilhado para ProjectItem ─────────────────────────────────
+const ITEM_SELECT = {
+  id: true,
+  name: true,
+  description: true,
+  quantity: true,
+  status: true,
+  priority: true,
+  transactionId: true,
+  createdAt: true,
+  updatedAt: true,
+  quotes: { select: QUOTE_SELECT, orderBy: { createdAt: 'asc' as const } },
+} as const;
+
+// ─── Seletor compartilhado para Project ──────────────────────────────────────
+const PROJECT_SELECT = {
+  id: true,
+  userId: true,
+  name: true,
+  description: true,
+  status: true,
+  totalBudget: true,
+  deadline: true,
+  color: true,
+  icon: true,
+  createdAt: true,
+  updatedAt: true,
+  _count: { select: { items: true } },
+} as const;
+
+@Injectable()
+export class ProjectsService {
+  private readonly logger = new Logger(ProjectsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly websocketService: WebsocketService,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  // ═══════════════════════════════════════════════════════════════
+  //  PROJECTS
+  // ═══════════════════════════════════════════════════════════════
+
+  async createProject(userId: string, dto: CreateProjectDto) {
+    const project = await this.prisma.project.create({
+      data: {
+        userId,
+        name: dto.name,
+        description: dto.description,
+        totalBudget: dto.totalBudget,
+        deadline: dto.deadline ? new Date(dto.deadline) : undefined,
+        color: dto.color ?? '#6366F1',
+        icon: dto.icon,
+        status: ProjectStatus.PLANNING,
+      },
+      select: { ...PROJECT_SELECT, items: { select: ITEM_SELECT } },
+    });
+
+    await this.cacheService.invalidateUserCache(userId);
+    return project;
+  }
+
+  async findAllProjects(userId: string, status?: ProjectStatus) {
+    return this.prisma.project.findMany({
+      where: { userId, ...(status && { status }) },
+      select: PROJECT_SELECT,
+      orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+    });
+  }
+
+  async findOneProject(userId: string, projectId: string) {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: {
+        ...PROJECT_SELECT,
+        items: {
+          select: ITEM_SELECT,
+          orderBy: [
+            { priority: 'asc' as const },
+            { createdAt: 'asc' as const },
+          ],
+        },
+      },
+    });
+
+    this.assertOwner(project, userId, 'Projeto');
+    return project;
+  }
+
+  async updateProject(
+    userId: string,
+    projectId: string,
+    dto: UpdateProjectDto,
+  ) {
+    await this.resolveProject(userId, projectId);
+
+    const updated = await this.prisma.project.update({
+      where: { id: projectId },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.totalBudget !== undefined && { totalBudget: dto.totalBudget }),
+        ...(dto.deadline !== undefined && {
+          deadline: dto.deadline ? new Date(dto.deadline) : null,
+        }),
+        ...(dto.color !== undefined && { color: dto.color }),
+        ...(dto.icon !== undefined && { icon: dto.icon }),
+        ...(dto.status !== undefined && { status: dto.status }),
+      },
+      select: { ...PROJECT_SELECT, items: { select: ITEM_SELECT } },
+    });
+
+    await this.cacheService.invalidateUserCache(userId);
+    return updated;
+  }
+
+  async removeProject(userId: string, projectId: string) {
+    await this.resolveProject(userId, projectId);
+
+    await this.prisma.project.delete({ where: { id: projectId } });
+    await this.cacheService.invalidateUserCache(userId);
+
+    return { message: 'Projeto removido com sucesso' };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  SUMMARY — Dashboard de progresso
+  // ═══════════════════════════════════════════════════════════════
+
+  async getProjectSummary(userId: string, projectId: string) {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      include: {
+        items: {
+          include: {
+            quotes: true,
+          },
+        },
+      },
+    });
+
+    this.assertOwner(project, userId, 'Projeto');
+
+    const items = project.items;
+    const totalItems = items.length;
+
+    let totalBudgeted = 0; // soma dos orçamentos selecionados
+    let totalSpent = 0; // soma das transações geradas
+    let totalRejected = 0; // soma dos orçamentos rejeitados (para calcular economia)
+    const purchasedItems: typeof items = [];
+    const pendingItems: typeof items = [];
+    const cancelledItems: typeof items = [];
+
+    for (const item of items) {
+      if (item.status === ProjectItemStatus.PURCHASED) {
+        purchasedItems.push(item);
+      } else if (item.status === ProjectItemStatus.CANCELLED) {
+        cancelledItems.push(item);
+      } else {
+        pendingItems.push(item);
+      }
+
+      // Calcular orçamento selecionado do item
+      const selectedQuote = item.quotes.find(
+        (q) =>
+          q.status === QuoteStatus.SELECTED ||
+          q.status === QuoteStatus.CONVERTED,
+      );
+      if (selectedQuote) {
+        const itemTotal =
+          Number(selectedQuote.price) + Number(selectedQuote.additionalCosts);
+        totalBudgeted += itemTotal;
+
+        if (item.status === ProjectItemStatus.PURCHASED) {
+          totalSpent += itemTotal;
+        }
+      }
+
+      // Calcular soma dos orçamentos rejeitados
+      for (const q of item.quotes) {
+        if (q.status === QuoteStatus.REJECTED) {
+          totalRejected += Number(q.price) + Number(q.additionalCosts);
+        }
+      }
+    }
+
+    // Economia = quanto seria gasto nos orçamentos rejeitados vs. o que foi realmente selecionado
+    // (só conta para itens já comprados)
+    let savingsVsRejected = 0;
+    for (const item of purchasedItems) {
+      const selectedQuote = item.quotes.find(
+        (q) => q.status === QuoteStatus.CONVERTED,
+      );
+      if (!selectedQuote) continue;
+
+      const selectedTotal =
+        Number(selectedQuote.price) + Number(selectedQuote.additionalCosts);
+
+      // Soma de tudo que foi rejeitado para esse item
+      const rejectedTotal = item.quotes
+        .filter((q) => q.status === QuoteStatus.REJECTED)
+        .reduce(
+          (acc, q) => acc + Number(q.price) + Number(q.additionalCosts),
+          0,
+        );
+
+      // A "economia" é a diferença entre os rejeitados e o que foi pago
+      savingsVsRejected += Math.max(0, rejectedTotal - selectedTotal);
+    }
+
+    const progressPercent =
+      totalItems > 0
+        ? Math.round(
+            ((purchasedItems.length + cancelledItems.length) / totalItems) *
+              100,
+          )
+        : 0;
+
+    return {
+      project: {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        status: project.status,
+        deadline: project.deadline,
+        color: project.color,
+        icon: project.icon,
+        totalBudget: project.totalBudget ? Number(project.totalBudget) : null,
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt,
+      },
+      stats: {
+        totalItems,
+        purchasedItems: purchasedItems.length,
+        pendingItems: pendingItems.length,
+        cancelledItems: cancelledItems.length,
+        totalBudgeted: +totalBudgeted.toFixed(2),
+        totalSpent: +totalSpent.toFixed(2),
+        estimatedRemaining: +(totalBudgeted - totalSpent).toFixed(2),
+        progressPercent,
+        savingsVsRejected: +savingsVsRejected.toFixed(2),
+        budgetVariance: project.totalBudget
+          ? +(Number(project.totalBudget) - totalBudgeted).toFixed(2)
+          : null,
+      },
+      items: items.map((item) => ({
+        ...item,
+        quotes: item.quotes.map((q) => ({
+          ...q,
+          price: Number(q.price),
+          additionalCosts: Number(q.additionalCosts),
+          total: +(Number(q.price) + Number(q.additionalCosts)).toFixed(2),
+        })),
+      })),
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  PROJECT ITEMS
+  // ═══════════════════════════════════════════════════════════════
+
+  async addItem(userId: string, projectId: string, dto: CreateProjectItemDto) {
+    await this.resolveProject(userId, projectId);
+
+    const item = await this.prisma.projectItem.create({
+      data: {
+        projectId,
+        name: dto.name,
+        description: dto.description,
+        quantity: dto.quantity ?? 1,
+        priority: dto.priority ?? 3,
+        status: ProjectItemStatus.PENDING,
+      },
+      select: ITEM_SELECT,
+    });
+
+    return item;
+  }
+
+  async updateItem(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    dto: UpdateProjectItemDto,
+  ) {
+    await this.resolveItem(userId, projectId, itemId);
+
+    const updated = await this.prisma.projectItem.update({
+      where: { id: itemId },
+      data: {
+        ...(dto.name !== undefined && { name: dto.name }),
+        ...(dto.description !== undefined && { description: dto.description }),
+        ...(dto.quantity !== undefined && { quantity: dto.quantity }),
+        ...(dto.priority !== undefined && { priority: dto.priority }),
+        // Não permite alterar para PURCHASED via PATCH -> use /convert
+        ...(dto.status !== undefined &&
+          dto.status !== ProjectItemStatus.PURCHASED && {
+            status: dto.status,
+          }),
+      },
+      select: ITEM_SELECT,
+    });
+
+    return updated;
+  }
+
+  async removeItem(userId: string, projectId: string, itemId: string) {
+    await this.resolveItem(userId, projectId, itemId);
+
+    await this.prisma.projectItem.delete({ where: { id: itemId } });
+
+    // Recalcular status do projeto após remoção
+    await this.syncProjectStatus(projectId);
+
+    return { message: 'Item removido com sucesso' };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  QUOTES
+  // ═══════════════════════════════════════════════════════════════
+
+  async addQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    dto: CreateQuoteDto,
+  ) {
+    const item = await this.resolveItem(userId, projectId, itemId);
+
+    if (item.status === ProjectItemStatus.PURCHASED) {
+      throw new ConflictException(
+        'Não é possível adicionar cotação a um item já comprado',
+      );
+    }
+
+    const quote = await this.prisma.quote.create({
+      data: {
+        itemId,
+        supplierName: dto.supplierName,
+        price: dto.price,
+        additionalCosts: dto.additionalCosts ?? 0,
+        notes: dto.notes,
+        status: QuoteStatus.PENDING,
+      },
+      select: QUOTE_SELECT,
+    });
+
+    // Ao adicionar a primeira cotação, item passa para QUOTED
+    if (item.status === ProjectItemStatus.PENDING) {
+      await this.prisma.projectItem.update({
+        where: { id: itemId },
+        data: { status: ProjectItemStatus.QUOTED },
+      });
+    }
+
+    return {
+      ...quote,
+      price: Number(quote.price),
+      additionalCosts: Number(quote.additionalCosts),
+      total: +(Number(quote.price) + Number(quote.additionalCosts)).toFixed(2),
+    };
+  }
+
+  async updateQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    quoteId: string,
+    dto: UpdateQuoteDto,
+  ) {
+    const quote = await this.resolveQuote(userId, projectId, itemId, quoteId);
+
+    if (quote.status === QuoteStatus.CONVERTED) {
+      throw new ConflictException(
+        'Não é possível editar uma cotação já convertida em transação',
+      );
+    }
+
+    const updated = await this.prisma.quote.update({
+      where: { id: quoteId },
+      data: {
+        ...(dto.supplierName !== undefined && {
+          supplierName: dto.supplierName,
+        }),
+        ...(dto.price !== undefined && { price: dto.price }),
+        ...(dto.additionalCosts !== undefined && {
+          additionalCosts: dto.additionalCosts,
+        }),
+        ...(dto.notes !== undefined && { notes: dto.notes }),
+      },
+      select: QUOTE_SELECT,
+    });
+
+    return {
+      ...updated,
+      price: Number(updated.price),
+      additionalCosts: Number(updated.additionalCosts),
+      total: +(Number(updated.price) + Number(updated.additionalCosts)).toFixed(
+        2,
+      ),
+    };
+  }
+
+  async removeQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    quoteId: string,
+  ) {
+    const quote = await this.resolveQuote(userId, projectId, itemId, quoteId);
+
+    if (quote.status === QuoteStatus.CONVERTED) {
+      throw new ConflictException(
+        'Não é possível remover uma cotação já convertida em transação',
+      );
+    }
+
+    await this.prisma.quote.delete({ where: { id: quoteId } });
+
+    // Se não há mais cotações, item volta para PENDING
+    const remaining = await this.prisma.quote.count({ where: { itemId } });
+    if (remaining === 0) {
+      await this.prisma.projectItem.update({
+        where: { id: itemId },
+        data: { status: ProjectItemStatus.PENDING },
+      });
+    }
+
+    return { message: 'Cotação removida com sucesso' };
+  }
+
+  // ─── Selecionar orçamento (desmarca automaticamente os outros do item) ──────
+
+  async selectQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    quoteId: string,
+  ) {
+    const quote = await this.resolveQuote(userId, projectId, itemId, quoteId);
+
+    if (quote.status === QuoteStatus.CONVERTED) {
+      throw new ConflictException(
+        'Esta cotação já foi convertida em transação',
+      );
+    }
+
+    // Transação atômica: desmarcar todos → marcar o escolhido
+    const [, selected] = await this.prisma.$transaction([
+      // 1. Todas as SELECTED/REJECTED do item voltam para PENDING
+      this.prisma.quote.updateMany({
+        where: {
+          itemId,
+          id: { not: quoteId },
+          status: { in: [QuoteStatus.SELECTED, QuoteStatus.PENDING] },
+        },
+        data: { status: QuoteStatus.PENDING },
+      }),
+      // 2. Marcar a cotação escolhida como SELECTED
+      this.prisma.quote.update({
+        where: { id: quoteId },
+        data: { status: QuoteStatus.SELECTED },
+        select: QUOTE_SELECT,
+      }),
+    ]);
+
+    return {
+      ...selected,
+      price: Number(selected.price),
+      additionalCosts: Number(selected.additionalCosts),
+      total: +(
+        Number(selected.price) + Number(selected.additionalCosts)
+      ).toFixed(2),
+    };
+  }
+
+  // ─── Rejeitar cotação ──────────────────────────────────────────────────────
+
+  async rejectQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    quoteId: string,
+  ) {
+    const quote = await this.resolveQuote(userId, projectId, itemId, quoteId);
+
+    if (quote.status === QuoteStatus.CONVERTED) {
+      throw new ConflictException(
+        'Esta cotação já foi convertida em transação',
+      );
+    }
+
+    const updated = await this.prisma.quote.update({
+      where: { id: quoteId },
+      data: { status: QuoteStatus.REJECTED },
+      select: QUOTE_SELECT,
+    });
+
+    return {
+      ...updated,
+      price: Number(updated.price),
+      additionalCosts: Number(updated.additionalCosts),
+      total: +(Number(updated.price) + Number(updated.additionalCosts)).toFixed(
+        2,
+      ),
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  CONVERT — Cotação selecionada → Transação real
+  // ═══════════════════════════════════════════════════════════════
+
+  async convertQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    dto: ConvertQuoteDto,
+  ) {
+    // 1. Validar contexto completo
+    const item = await this.resolveItem(userId, projectId, itemId);
+    const project = item['project'] as { name: string } | undefined;
+
+    if (item.status === ProjectItemStatus.PURCHASED) {
+      throw new ConflictException('Este item já foi comprado anteriormente');
+    }
+
+    // 2. Buscar cotação selecionada
+    const selectedQuote = await this.prisma.quote.findFirst({
+      where: { itemId, status: QuoteStatus.SELECTED },
+    });
+
+    if (!selectedQuote) {
+      throw new UnprocessableEntityException(
+        'Selecione uma cotação antes de converter. Use PATCH .../quotes/:id/select',
+      );
+    }
+
+    // 3. Validar que a conta existe e pertence ao usuário
+    const account = await this.prisma.account.findUnique({
+      where: { id: dto.accountId },
+    });
+    if (!account) {
+      throw new NotFoundException('Conta não encontrada');
+    }
+    if (account.userId !== userId) {
+      throw new ForbiddenException(
+        'Você não tem permissão para usar esta conta',
+      );
+    }
+
+    // 4. Validar categoria (se fornecida) — deve ser do tipo EXPENSE
+    if (dto.categoryId) {
+      const category = await this.prisma.category.findUnique({
+        where: { id: dto.categoryId },
+      });
+      if (!category) {
+        throw new NotFoundException('Categoria não encontrada');
+      }
+      if (category.type !== 'EXPENSE') {
+        throw new UnprocessableEntityException(
+          'Apenas categorias do tipo EXPENSE podem ser usadas em conversões',
+        );
+      }
+    }
+
+    const totalAmount =
+      Number(selectedQuote.price) + Number(selectedQuote.additionalCosts);
+
+    // 5. Executar tudo em uma transação de banco
+    const result = await this.prisma.$transaction(async (tx) => {
+      // 5a. Criar transaction financeira
+      const transaction = await tx.transaction.create({
+        data: {
+          userId,
+          accountId: dto.accountId,
+          categoryId: dto.categoryId ?? null,
+          type: TransactionType.EXPENSE,
+          amount: totalAmount,
+          description: `[Projeto] ${item.name}`,
+          notes: dto.notes
+            ? dto.notes
+            : `Projeto: ${item.name} — Fornecedor: ${selectedQuote.supplierName}`,
+          date: dto.date ? new Date(dto.date) : new Date(),
+          status: TransactionStatus.COMPLETED,
+          source: TransactionSource.MANUAL,
+          tags: ['projeto'],
+          isRecurring: false,
+        },
+        include: {
+          category: { select: { id: true, name: true, color: true } },
+          account: { select: { id: true, name: true, type: true } },
+        },
+      });
+
+      // 5b. Atualizar saldo da conta
+      await tx.account.update({
+        where: { id: dto.accountId },
+        data: {
+          currentBalance: {
+            decrement: new Prisma.Decimal(totalAmount),
+          },
+        },
+      });
+
+      // 5c. Marcar cotação como CONVERTED
+      await tx.quote.update({
+        where: { id: selectedQuote.id },
+        data: { status: QuoteStatus.CONVERTED },
+      });
+
+      // 5d. Marcar item como PURCHASED com referência à transação
+      const updatedItem = await tx.projectItem.update({
+        where: { id: itemId },
+        data: {
+          status: ProjectItemStatus.PURCHASED,
+          transactionId: transaction.id,
+        },
+        select: ITEM_SELECT,
+      });
+
+      return { transaction, item: updatedItem };
+    });
+
+    // 6. Atualizar status do projeto (se todos itens estiverem concluídos)
+    const newProjectStatus = await this.syncProjectStatus(projectId);
+
+    // 7. Emitir evento WebSocket
+    this.websocketService.emitToUser(userId, WS_EVENTS.BALANCE_UPDATED, {
+      accountId: dto.accountId,
+      newBalance: Number(account.currentBalance) - totalAmount,
+      difference: -totalAmount,
+    });
+
+    this.logger.log(
+      `Project item converted: item=${itemId}, transaction=${result.transaction.id}, amount=${totalAmount}`,
+    );
+
+    await this.cacheService.invalidateUserCache(userId);
+
+    return {
+      transaction: result.transaction,
+      item: result.item,
+      projectStatus: newProjectStatus,
+      totalConverted: +totalAmount.toFixed(2),
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════
+  //  HELPERS PRIVADOS
+  // ═══════════════════════════════════════════════════════════════
+
+  /**
+   * Resolve um projeto validando a propriedade.
+   * Lança NotFoundException tanto se não existe quanto se é de outro usuário
+   * (nunca revelamos ao chamador que o recurso existe mas pertence a outro).
+   */
+  private async resolveProject(userId: string, projectId: string) {
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: { id: true, userId: true, name: true, status: true },
+    });
+
+    this.assertOwner(project, userId, 'Projeto');
+    return project!;
+  }
+
+  /**
+   * Resolve um item validando a cadeia project → item → owner.
+   */
+  private async resolveItem(userId: string, projectId: string, itemId: string) {
+    const item = await this.prisma.projectItem.findUnique({
+      where: { id: itemId },
+      include: {
+        project: { select: { id: true, userId: true, name: true } },
+        quotes: { select: QUOTE_SELECT },
+      },
+    });
+
+    if (!item || item.projectId !== projectId) {
+      throw new NotFoundException('Item não encontrado');
+    }
+    if (item.project.userId !== userId) {
+      throw new NotFoundException('Item não encontrado');
+    }
+
+    return item;
+  }
+
+  /**
+   * Resolve uma cotação validando a cadeia project → item → quote → owner.
+   */
+  private async resolveQuote(
+    userId: string,
+    projectId: string,
+    itemId: string,
+    quoteId: string,
+  ) {
+    const quote = await this.prisma.quote.findUnique({
+      where: { id: quoteId },
+      include: {
+        item: {
+          include: {
+            project: { select: { id: true, userId: true } },
+          },
+        },
+      },
+    });
+
+    if (
+      !quote ||
+      quote.itemId !== itemId ||
+      quote.item.projectId !== projectId
+    ) {
+      throw new NotFoundException('Cotação não encontrada');
+    }
+    if (quote.item.project.userId !== userId) {
+      throw new NotFoundException('Cotação não encontrada');
+    }
+
+    return quote;
+  }
+
+  /**
+   * Lança NotFoundException se o recurso não existe ou userId não bate.
+   */
+  private assertOwner(
+    resource: { userId: string } | null | undefined,
+    userId: string,
+    entityName: string,
+  ): asserts resource is NonNullable<typeof resource> {
+    if (!resource || resource.userId !== userId) {
+      throw new NotFoundException(`${entityName} não encontrado`);
+    }
+  }
+
+  /**
+   * Recalcula e persiste o ProjectStatus com base nos itens atuais.
+   * Regras:
+   *   - Sem itens não-cancelados → PLANNING
+   *   - Todos os itens não-cancelados PURCHASED → COMPLETED
+   *   - Ao menos 1 PURCHASED → IN_PROGRESS
+   *   - Caso contrário → PLANNING
+   */
+  private async syncProjectStatus(projectId: string): Promise<ProjectStatus> {
+    const items = await this.prisma.projectItem.findMany({
+      where: { projectId },
+      select: { status: true },
+    });
+
+    const active = items.filter(
+      (i) => i.status !== ProjectItemStatus.CANCELLED,
+    );
+
+    let newStatus: ProjectStatus;
+
+    if (active.length === 0) {
+      newStatus = ProjectStatus.PLANNING;
+    } else if (active.every((i) => i.status === ProjectItemStatus.PURCHASED)) {
+      newStatus = ProjectStatus.COMPLETED;
+    } else if (active.some((i) => i.status === ProjectItemStatus.PURCHASED)) {
+      newStatus = ProjectStatus.IN_PROGRESS;
+    } else {
+      newStatus = ProjectStatus.PLANNING;
+    }
+
+    await this.prisma.project.update({
+      where: { id: projectId },
+      data: { status: newStatus },
+    });
+
+    return newStatus;
+  }
+}

--- a/test/projects.e2e-spec.ts
+++ b/test/projects.e2e-spec.ts
@@ -1,0 +1,353 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { cleanDatabase, generateTestEmail } from './utils/test-utils';
+
+describe('Projects (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let accessToken: string;
+  let accountId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+
+    await app.init();
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await cleanDatabase(prisma);
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase(prisma);
+
+    const email = generateTestEmail();
+    const registerRes = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email, password: 'Test@123456', fullName: 'Test User' });
+
+    accessToken = registerRes.body.accessToken;
+
+    const accountRes = await request(app.getHttpServer())
+      .post('/accounts')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: 'Conta Teste', type: 'CHECKING', initialBalance: 5000 });
+
+    accountId = accountRes.body.id;
+  });
+
+  // ═══ POST /projects ══════════════════════════════════════════════════════════
+
+  describe('POST /projects', () => {
+    it('deve criar projeto com campos básicos', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Arrumar Carro', totalBudget: 1000 })
+        .expect(201);
+
+      expect(res.body).toMatchObject({
+        name: 'Arrumar Carro',
+        status: 'PLANNING',
+      });
+      expect(res.body).toHaveProperty('id');
+    });
+
+    it('deve retornar 401 sem token', () => {
+      return request(app.getHttpServer())
+        .post('/projects')
+        .send({ name: 'Proj' })
+        .expect(401);
+    });
+
+    it('deve retornar 400 com nome muito curto', () => {
+      return request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'X' })
+        .expect(400);
+    });
+  });
+
+  // ═══ GET /projects ═══════════════════════════════════════════════════════════
+
+  describe('GET /projects', () => {
+    it('deve listar projetos do usuário', async () => {
+      await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Projeto A' });
+
+      await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Projeto B' });
+
+      const res = await request(app.getHttpServer())
+        .get('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body).toHaveLength(2);
+    });
+
+    it('deve filtrar por status', async () => {
+      await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Planejando' });
+
+      const res = await request(app.getHttpServer())
+        .get('/projects?status=PLANNING')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.every((p) => p.status === 'PLANNING')).toBe(true);
+    });
+  });
+
+  // ═══ Fluxo completo: Projeto → Item → Cotação → Selecionar → Converter ══════
+
+  describe('Fluxo completo de projeto', () => {
+    let projectId: string;
+    let itemId: string;
+    let quoteId: string;
+    let quoteId2: string;
+
+    beforeEach(async () => {
+      // 1. Criar projeto
+      const projRes = await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({
+          name: 'Arrumar Carro',
+          totalBudget: 1500,
+          deadline: '2026-12-31',
+        })
+        .expect(201);
+      projectId = projRes.body.id;
+
+      // 2. Adicionar item
+      const itemRes = await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Bateria nova', priority: 1 })
+        .expect(201);
+      itemId = itemRes.body.id;
+
+      // 3. Adicionar cotações
+      const q1 = await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/quotes`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ supplierName: 'AutoPeças', price: 450 })
+        .expect(201);
+      quoteId = q1.body.id;
+
+      const q2 = await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/quotes`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ supplierName: 'MercadoLivre', price: 420, additionalCosts: 30 })
+        .expect(201);
+      quoteId2 = q2.body.id;
+    });
+
+    it('item deve estar QUOTED após adicionar cotação', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/projects/${projectId}`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      const item = res.body.items.find((i) => i.id === itemId);
+      expect(item.status).toBe('QUOTED');
+      expect(item.quotes).toHaveLength(2);
+    });
+
+    it('deve selecionar cotação e desmarcar as demais', async () => {
+      // Selecionar cotação 1
+      await request(app.getHttpServer())
+        .patch(
+          `/projects/${projectId}/items/${itemId}/quotes/${quoteId}/select`,
+        )
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      // Selecionar cotação 2 (deve desmarcar a 1)
+      const res = await request(app.getHttpServer())
+        .patch(
+          `/projects/${projectId}/items/${itemId}/quotes/${quoteId2}/select`,
+        )
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('SELECTED');
+
+      // Verificar que cotação 1 voltou para PENDING
+      const projRes = await request(app.getHttpServer())
+        .get(`/projects/${projectId}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+      const item = projRes.body.items.find((i) => i.id === itemId);
+      const q1 = item.quotes.find((q) => q.id === quoteId);
+      expect(q1.status).toBe('PENDING');
+    });
+
+    it('deve converter cotação selecionada em transação e debitar saldo', async () => {
+      // Selecionar cotação 1 (R$ 450)
+      await request(app.getHttpServer())
+        .patch(
+          `/projects/${projectId}/items/${itemId}/quotes/${quoteId}/select`,
+        )
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Converter
+      const convertRes = await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId })
+        .expect(201);
+
+      expect(convertRes.body).toHaveProperty('transaction');
+      expect(convertRes.body.transaction.type).toBe('EXPENSE');
+      expect(Number(convertRes.body.transaction.amount)).toBe(450);
+      expect(convertRes.body.item.status).toBe('PURCHASED');
+      expect(convertRes.body.totalConverted).toBe(450);
+
+      // Saldo da conta deve ter sido debitado
+      const accountRes = await request(app.getHttpServer())
+        .get(`/accounts/${accountId}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+      expect(Number(accountRes.body.currentBalance)).toBe(4550); // 5000 - 450
+    });
+
+    it('deve marcar projeto como COMPLETED após todos os itens comprados', async () => {
+      await request(app.getHttpServer())
+        .patch(
+          `/projects/${projectId}/items/${itemId}/quotes/${quoteId}/select`,
+        )
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      const convertRes = await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId });
+
+      expect(convertRes.body.projectStatus).toBe('COMPLETED');
+    });
+
+    it('deve retornar 409 ao tentar converter item já comprado', async () => {
+      // Primeira conversão
+      await request(app.getHttpServer())
+        .patch(
+          `/projects/${projectId}/items/${itemId}/quotes/${quoteId}/select`,
+        )
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId });
+
+      // Segunda tentativa → deve falhar
+      await request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId })
+        .expect(409);
+    });
+
+    it('deve retornar 422 ao converter sem cotação selecionada', () => {
+      return request(app.getHttpServer())
+        .post(`/projects/${projectId}/items/${itemId}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId })
+        .expect(422);
+    });
+  });
+
+  // ═══ GET /projects/:id/summary ═══════════════════════════════════════════════
+
+  describe('GET /projects/:id/summary', () => {
+    it('deve retornar resumo com estatísticas corretas', async () => {
+      // Criar projeto com 1 item e 1 cotação convertida
+      const projRes = await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Test Summary', totalBudget: 1000 })
+        .expect(201);
+      const pid = projRes.body.id;
+
+      const itemRes = await request(app.getHttpServer())
+        .post(`/projects/${pid}/items`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Item A' });
+      const iid = itemRes.body.id;
+
+      const qRes = await request(app.getHttpServer())
+        .post(`/projects/${pid}/items/${iid}/quotes`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ supplierName: 'Loja X', price: 300 });
+      const qid = qRes.body.id;
+
+      await request(app.getHttpServer())
+        .patch(`/projects/${pid}/items/${iid}/quotes/${qid}/select`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      await request(app.getHttpServer())
+        .post(`/projects/${pid}/items/${iid}/convert`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ accountId });
+
+      const summaryRes = await request(app.getHttpServer())
+        .get(`/projects/${pid}/summary`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(summaryRes.body.stats.progressPercent).toBe(100);
+      expect(summaryRes.body.stats.totalSpent).toBe(300);
+      expect(summaryRes.body.stats.budgetVariance).toBe(700); // 1000 - 300
+    });
+  });
+
+  // ═══ Isolamento entre usuários ════════════════════════════════════════════════
+
+  describe('Isolamento entre usuários', () => {
+    it('não deve permitir acesso a projeto de outro usuário', async () => {
+      // Criar projeto com user1
+      const projRes = await request(app.getHttpServer())
+        .post('/projects')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Meu Projeto' })
+        .expect(201);
+      const pid = projRes.body.id;
+
+      // Registrar user2
+      const email2 = generateTestEmail();
+      const res2 = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({ email: email2, password: 'Test@123456', fullName: 'User 2' });
+      const token2 = res2.body.accessToken;
+
+      // User2 tenta acessar projeto do user1
+      await request(app.getHttpServer())
+        .get(`/projects/${pid}`)
+        .set('Authorization', `Bearer ${token2}`)
+        .expect(404);
+    });
+  });
+});

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -5,13 +5,15 @@ import { PrismaService } from '../../src/prisma/prisma.service';
 /**
  * Cria app NestJS configurado para testes E2E
  */
-export async function createTestApp(moduleImports: any[]): Promise<INestApplication> {
+export async function createTestApp(
+  moduleImports: any[],
+): Promise<INestApplication> {
   const moduleFixture: TestingModule = await Test.createTestingModule({
     imports: moduleImports,
   }).compile();
 
   const app = moduleFixture.createNestApplication();
-  
+
   // Aplicar mesmas configurações do main.ts
   app.useGlobalPipes(
     new ValidationPipe({
@@ -31,6 +33,10 @@ export async function createTestApp(moduleImports: any[]): Promise<INestApplicat
 export async function cleanDatabase(prisma: PrismaService) {
   // Ordem importa devido a foreign keys
   await prisma.notification.deleteMany();
+  // Projects (Issue #79) — deve vir antes de transactions para evitar FK
+  await prisma.quote.deleteMany();
+  await prisma.projectItem.deleteMany();
+  await prisma.project.deleteMany();
   await prisma.transaction.deleteMany();
   await prisma.recurringTransaction.deleteMany();
   await prisma.budget.deleteMany();


### PR DESCRIPTION
- Adiciona modelos Project, ProjectItem e Quote ao schema Prisma
- Cria migration: add_projects_items_quotes_issue_79
- Implementa ProjectsService com logica completa:
  - CRUD de projetos, itens e cotacoes
  - selectQuote: marca SELECTED e desmarca outros atomicamente
  - convertQuote: cotacao -> Transaction real + debito de saldo + PURCHASED
  - syncProjectStatus: PLANNING -> IN_PROGRESS -> COMPLETED automatico
  - getProjectSummary: dashboard com totais, economia e progresso%
- Implementa ProjectsController com 14 endpoints + Swagger completo
- Validacao de userId em todas as operacoes (nunca vaza 403, retorna 404)
- Emite WebSocket BALANCE_UPDATED apos conversao
- Invalida cache do usuario apos escrita
- 21 testes unitarios (projects.service.spec.ts) - todos passando
- Testes E2E (test/projects.e2e-spec.ts) com fluxo completo e isolamento
- Atualiza cleanDatabase em test-utils para incluir novos modelos